### PR TITLE
REXML::ParseException replaced by EOFError

### DIFF
--- a/workflow/Makefile.erb
+++ b/workflow/Makefile.erb
@@ -201,7 +201,7 @@ tmpfile = $(dir $1).$(notdir $1)
   require 'rexml/parsers/streamparser'
   require 'rexml/streamlistener'
 
-  class EndOfOntology < REXML::ParseException
+  class EndOfOntology < EOFError
   end
   
   class OntologyListener
@@ -214,7 +214,6 @@ tmpfile = $(dir $1).$(notdir $1)
         @in_ontology = (name == 'owl:Ontology')
       when 'owl:imports'
         @imports << attrs['rdf:resource']
-      else
       end
     end
     def tag_end(name)


### PR DESCRIPTION
Apparently not available in jruby-1.7.19.